### PR TITLE
bitcore support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ sudo: false
 language: node_js
 node_js:
   - "4.0.0"
-  - "0.12"
   - "iojs"
+  - "0.12"
+  - "0.10"
 env:
   - TEST_SUITE=coverage
   - TEST_SUITE=standard

--- a/README.md
+++ b/README.md
@@ -18,27 +18,27 @@ var bitcoinjs = require('bitcoinjs-lib')
 var bip69 = require('bip69')
 
 var inputs = [{
-	"txId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-	"vout": 0
+  "txId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "vout": 0
 }, ...]
 var outputs = [{
-	"script": new Buffer("76a9145be32612930b8323add2212a4ec03c1562084f8488ac", "hex"),
-	"value": 40000000000
+  "script": new Buffer("76a9145be32612930b8323add2212a4ec03c1562084f8488ac", "hex"),
+  "value": 40000000000
 }, ...]
 
 // ...
 
-var sortedInputs = bip69.sortInputs(inputs)
-var sortedOutputs = bip69.sortOutputs(outputs)
+var sortedInputs = bip69.bitcoinjs.sortInputs(inputs)
+var sortedOutputs = bip69.bitcoinjs.sortOutputs(outputs)
 
 var txb = new bitcoinjs.TransactionBuilder()
 
 sortetInputs.forEach(function (input) {
-	txb.addInput(input.txId, input.vout)
+  txb.addInput(input.txId, input.vout)
 })
 
 sortedOutputs.forEach(function (output) {
-	txb.addOutput(bitcoinjs.Script.fromBuffer(output.script), output.value)
+  txb.addOutput(bitcoinjs.Script.fromBuffer(output.script), output.value)
 })
 
 // ... and so on

--- a/bitcoinjs.js
+++ b/bitcoinjs.js
@@ -1,0 +1,17 @@
+var bufferCompare = Buffer.compare || require('buffer-compare')
+
+// Previous transaction hashes (in reversed byte-order) are to be sorted in ascending order, lexicographically.
+// In the event of two matching transaction hashes, the respective previous output indices will be compared by their integer value, in ascending order.
+// If the previous output indices match, the inputs are considered equal.
+function inputComparator (a, b) {
+  return a.txId.localeCompare(b.txId) || a.vout - b.vout
+}
+
+// Transaction output amounts (as 64-bit unsigned integers) are to be sorted in ascending order.
+// In the event of two matching output amounts, the respective output scriptPubKeys (as a byte-array) will be compared lexicographically, in ascending order.
+// If the scriptPubKeys match, the outputs are considered equal.
+function outputComparator (a, b) {
+  return a.value - b.value || bufferCompare(a.script, b.script)
+}
+
+module.exports = require('./exports')(inputComparator, outputComparator)

--- a/bitcore.js
+++ b/bitcore.js
@@ -1,26 +1,17 @@
+var bufferCompare = Buffer.compare || require('buffer-compare')
+
 // Previous transaction hashes (in reversed byte-order) are to be sorted in ascending order, lexicographically.
 // In the event of two matching transaction hashes, the respective previous output indices will be compared by their integer value, in ascending order.
 // If the previous output indices match, the inputs are considered equal.
 function inputComparator (a, b) {
-  return a.txId.localeCompare(b.txId) || a.vout - b.vout
+  return bufferCompare(a.prevTxId, b.prevTxId) || a.outputIndex - b.outputIndex
 }
 
 // Transaction output amounts (as 64-bit unsigned integers) are to be sorted in ascending order.
 // In the event of two matching output amounts, the respective output scriptPubKeys (as a byte-array) will be compared lexicographically, in ascending order.
 // If the scriptPubKeys match, the outputs are considered equal.
 function outputComparator (a, b) {
-  return a.value - b.value || a.script.compare(b.script)
+  return a.satoshis - b.satoshis || bufferCompare(a.script.toBuffer(), b.script.toBuffer())
 }
 
-function sortInputs (inputs) {
-  return inputs.concat().sort(inputComparator)
-}
-
-function sortOutputs (outputs) {
-  return outputs.concat().sort(outputComparator)
-}
-
-module.exports = {
-  sortInputs: sortInputs,
-  sortOutputs: sortOutputs
-}
+module.exports = require('./exports')(inputComparator, outputComparator)

--- a/exports.js
+++ b/exports.js
@@ -1,0 +1,10 @@
+module.exports = function (inputComparator, outputComparator) {
+  return {
+    sortInputs: function (inputs) {
+      return inputs.concat().sort(inputComparator)
+    },
+    sortOutputs: function (outputs) {
+      return outputs.concat().sort(outputComparator)
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bip69",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Lexicographical Indexing of Bitcoin Transaction Inputs and Outputs.",
   "author": "Daniel Cousens",
   "license": "MIT",
@@ -16,7 +16,7 @@
     "bip69",
     "bitcoin"
   ],
-  "main": "index.js",
+  "main": "./bitcoinjs.js",
   "scripts": {
     "coverage": "mocha --require blanket -R travis-cov",
     "coverage-local": "mocha --require blanket -R html-cov",
@@ -38,7 +38,9 @@
       "threshold": 100
     }
   },
-  "dependencies": {},
+  "dependencies": {
+    "buffer-compare": "^1.0.0"
+  },
   "devDependencies": {
     "blanket": "*",
     "mocha": "*",

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,6 @@
 /* global describe, it */
 
 var assert = require('assert')
-var bip69 = require('../')
 var fixtures = require('./fixtures')
 
 // returns index-based order of sorted against original
@@ -12,29 +11,78 @@ function getIndexOrder (original, sorted) {
 }
 
 describe('bip69', function () {
-  describe('sortInputs', function () {
-    fixtures.inputs.forEach(function (f) {
-      it('is ' + f.description, function () {
-        var actual = bip69.sortInputs(f.inputs)
-
-        assert.deepEqual(getIndexOrder(f.inputs, actual), f.expected)
+  function runTests (bip69, fixtures) {
+    describe('sortInputs', function () {
+      fixtures.inputs.forEach(function (f) {
+        it('is ' + f.description, function () {
+          var actual = bip69.sortInputs(f.inputs)
+          assert.deepEqual(getIndexOrder(f.inputs, actual), f.expected)
+        })
       })
     })
+
+    describe('sortOutputs', function () {
+      fixtures.outputs.forEach(function (f) {
+        it('is ' + f.description, function () {
+          var actual = bip69.sortOutputs(f.outputs)
+          assert.deepEqual(getIndexOrder(f.outputs, actual), f.expected)
+        })
+      })
+    })
+  }
+
+  describe('bitcoinjs', function () {
+    var bitcoinjsFixtures = {
+      inputs: fixtures.inputs,
+      outputs: fixtures.outputs.map(function (fixture) {
+        return {
+          description: fixture.description,
+          outputs: fixture.outputs.map(function (output) {
+            return {
+              value: output.value,
+              script: new Buffer(output.script)
+            }
+          }),
+          expected: fixture.expected
+        }
+      })
+    }
+
+    runTests(require('../bitcoinjs'), bitcoinjsFixtures)
   })
 
-  describe('sortOutputs', function () {
-    fixtures.outputs.forEach(function (f) {
-      it('is ' + f.description, function () {
-        var outputs = f.outputs.map(function (fo) {
-          return {
-            script: new Buffer(fo.script),
-            value: fo.value
-          }
-        })
-        var actual = bip69.sortOutputs(outputs)
-
-        assert.deepEqual(getIndexOrder(outputs, actual), f.expected)
+  describe('bitcore', function () {
+    var bitcoreFixtures = {
+      inputs: fixtures.inputs.map(function (fixture) {
+        return {
+          description: fixture.description,
+          inputs: fixture.inputs.map(function (input) {
+            return {
+              prevTxId: new Buffer(input.txId, 'hex'),
+              outputIndex: input.vout
+            }
+          }),
+          expected: fixture.expected
+        }
+      }),
+      outputs: fixtures.outputs.map(function (fixture) {
+        return {
+          description: fixture.description,
+          outputs: fixture.outputs.map(function (output) {
+            return {
+              satoshis: output.value,
+              script: {
+                toBuffer: function () {
+                  return new Buffer(output.script)
+                }
+              }
+            }
+          }),
+          expected: fixture.expected
+        }
       })
-    })
+    }
+
+    runTests(require('../bitcore'), bitcoreFixtures)
   })
 })


### PR DESCRIPTION
One of the way resolving https://github.com/bitpay/bitcore/pull/1340
Will be happy drop [buffer-compare](https://github.com/soldair/node-buffer-compare/) as dependency, but it's need for support node 0.10 :sob: 

with this `bitcore.Transactions.sort` can be looks like this:

``` js
var bip69 = require('bip69/src/bitcore')

Transaction.prototype.sort = function() {
  this.sortInputs(bip69.sortInputs)
  this.sortOutputs(bip69.sortOutputs)
  return this;
};
```

**EDIT**: merge is reasonable only if `bitcore` will use this package
